### PR TITLE
Add distance functions to Vec2 and Vec3

### DIFF
--- a/plask.js
+++ b/plask.js
@@ -804,21 +804,21 @@ Vec3.prototype.lengthSquared = function() {
   return x*x + y*y + z*z;
 };
 
-// Distance to Vec3 |b|
-Vec3.prototype.distance = function(b) {
+// Distance to Vec3 |b|.
+Vec3.prototype.dist = function(b) {
   var x = b.x - this.x;
   var y = b.y - this.y;
   var z = b.z - this.z;
   return Math.sqrt(x*x + y*y + z*z);
-}
+};
 
-// Squared Distance to Vec3 |b|
-Vec3.prototype.distanceSquared = function(b) {
+// Squared Distance to Vec3 |b|.
+Vec3.prototype.distSquared = function(b) {
   var x = b.x - this.x;
   var y = b.y - this.y;
   var z = b.z - this.z;
   return x*x + y*y + z*z;
-}
+};
 
 // Normalize, scaling so the magnitude is 1.  Invalid for a zero vector.
 Vec3.prototype.normalize = function() {
@@ -950,19 +950,19 @@ Vec2.prototype.lengthSquared = function() {
   return x*x + y*y;
 };
 
-// Distance to Vec2 |b|
-Vec2.prototype.distance = function(b) {
+// Distance to Vec2 |b|.
+Vec2.prototype.dist = function(b) {
   var x = b.x - this.x;
   var y = b.y - this.y;
   return Math.sqrt(x*x + y*y);
-}
+};
 
-// Squared Distance to Vec2 |b|
-Vec2.prototype.distanceSquared = function(b) {
+// Squared Distance to Vec2 |b|.
+Vec2.prototype.distSquared = function(b) {
   var x = b.x - this.x;
   var y = b.y - this.y;
   return x*x + y*y;
-}
+};
 
 // Normalize, scaling so the magnitude is 1.  Invalid for a zero vector.
 Vec2.prototype.normalize = function() {


### PR DESCRIPTION
I think we should have this. The other option is to do something like:

<pre>
vec2.subbed(vec1).length()
</pre>

which creates a new object, vs:

<pre>
vec1.distance(vec2)
</pre>
