### PR TITLE
Add location (x,y) to the filesDropped event

### DIFF
--- a/plask_bindings.mm
+++ b/plask_bindings.mm
@@ -5400,8 +5400,13 @@ class CAMIDIDestinationWrapper {
         [[paths objectAtIndex:i] UTF8String]));
   }
 
+  CGRect content_rect = [[[sender draggingDestinationWindow] contentView] frame];
+  CGPoint pos = [sender draggingLocation];
+
   v8::Local<v8::Object> res = v8::Object::New();
   res->Set(v8::String::New("paths"), jspaths);
+  res->Set(v8::String::New("x"), v8::Number::New(floor(pos.x)));
+  res->Set(v8::String::New("y"), v8::Number::New(floor(content_rect.size.height - pos.y)));
 
   v8::Handle<v8::Value> argv[] = { v8::Number::New(1), res };
   v8::TryCatch try_catch;


### PR DESCRIPTION
Uses [sender draggingLocation] and converts to top-left content-relative coordinates. I had to kill trailing spaces in here as well but I made it an extra commit in case you want to cherry-pick. But then.. no one likes those freeloading spaces, do they?
